### PR TITLE
Update to tgbotapi 34.0.0

### DIFF
--- a/bot/build.gradle.kts
+++ b/bot/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 dependencies {
     implementation(project(":common"))
 
-    implementation("com.github.centralhardware:ktgbotapi-commons:bf997d37")
+    implementation("com.github.centralhardware:ktgbotapi-commons:eb3d7671")
 }
 
 jib {

--- a/bot/src/main/kotlin/me/centralhardware/znatoki/telegram/statistic/Validators.kt
+++ b/bot/src/main/kotlin/me/centralhardware/znatoki/telegram/statistic/Validators.kt
@@ -4,7 +4,7 @@ import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
 import dev.inmo.tgbotapi.extensions.utils.extensions.raw.text
-import dev.inmo.tgbotapi.types.message.abstracts.CommonMessage
+import dev.inmo.tgbotapi.types.message.abstracts.ChatContentMessage
 import dev.inmo.tgbotapi.types.message.content.MessageContent
 import dev.inmo.tgbotapi.types.message.content.PhotoContent
 import dev.inmo.tgbotapi.types.message.content.TextContent
@@ -45,39 +45,39 @@ fun Int?.validateAmount(): Either<String, Unit> {
 }
 
 
-fun CommonMessage<MessageContent>.validateText(): Either<String, String> =
+fun ChatContentMessage<MessageContent>.validateText(): Either<String, String> =
     if (this.content is TextContent && StringUtils.isNotBlank(this.text)) {
         Either.Right(this.text!!)
     } else {
         Either.Left("Введите текст")
     }
 
-fun CommonMessage<MessageContent>.validateTelephone(): Either<String, String> =
+fun ChatContentMessage<MessageContent>.validateTelephone(): Either<String, String> =
     if (PhoneNumber.validate(this.text!!)) {
         Either.Right(this.text!!)
     } else {
         Either.Left("Введите номер телефона")
     }
 
-fun CommonMessage<MessageContent>.validateEnum(variants: List<String>): Either<String, String> =
+fun ChatContentMessage<MessageContent>.validateEnum(variants: List<String>): Either<String, String> =
     if (this.content is TextContent && variants.contains(this.text)) {
         Either.Right(this.text!!)
     } else {
         Either.Left("Выберите вариант из кастомный клавиатуры")
     }
 
-fun CommonMessage<MessageContent>.validateDate(): Either<String, LocalDate> =
+fun ChatContentMessage<MessageContent>.validateDate(): Either<String, LocalDate> =
     this.text.parseDate()
         .fold(
             { Either.Right(it) },
             { Either.Left("Ошибка обработки даты необходимо ввести в формате: дд ММ гггг") },
         )
 
-fun CommonMessage<MessageContent>.validateInt(): Either<String, Int> =
+fun ChatContentMessage<MessageContent>.validateInt(): Either<String, Int> =
     this.text?.toIntOrNull()?.right() ?: "Введите число".left()
 
 
-fun CommonMessage<MessageContent>.validatePhoto(): Either<String, Unit> =
+fun ChatContentMessage<MessageContent>.validatePhoto(): Either<String, Unit> =
     if (this.content is PhotoContent) {
         Either.Right(Unit)
     } else {

--- a/bot/src/main/kotlin/me/centralhardware/znatoki/telegram/statistic/extensions/CommonMessageExt.kt
+++ b/bot/src/main/kotlin/me/centralhardware/znatoki/telegram/statistic/extensions/CommonMessageExt.kt
@@ -5,7 +5,7 @@ import dev.inmo.tgbotapi.extensions.api.files.downloadFile
 import dev.inmo.tgbotapi.extensions.api.telegramBot
 import dev.inmo.tgbotapi.extensions.utils.asPhotoContent
 import dev.inmo.tgbotapi.extensions.utils.asTextContent
-import dev.inmo.tgbotapi.types.message.abstracts.CommonMessage
+import dev.inmo.tgbotapi.types.message.abstracts.ChatContentMessage
 import dev.inmo.tgbotapi.types.message.content.MessageContent
 import me.centralhardware.znatoki.telegram.statistic.entity.TutorId
 import me.centralhardware.znatoki.telegram.statistic.service.MinioService
@@ -13,14 +13,14 @@ import java.nio.file.Files
 import java.time.LocalDateTime
 import kotlin.io.path.writeBytes
 
-fun CommonMessage<MessageContent>.userId(): Long = chat.id.chatId.long
-fun CommonMessage<MessageContent>.tutorId(): TutorId = TutorId(this.userId())
+fun ChatContentMessage<MessageContent>.userId(): Long = chat.id.chatId.long
+fun ChatContentMessage<MessageContent>.tutorId(): TutorId = TutorId(this.userId())
 
-suspend fun CommonMessage<MessageContent>.extract(): String {
+suspend fun ChatContentMessage<MessageContent>.extract(): String {
     val photo = this.content.asPhotoContent()!!.media
     val temp = Files.createTempFile("tg", "sdf")
     temp.writeBytes(telegramBot(AppConfig.botToken()).downloadFile(photo))
     return MinioService.upload(temp.toFile(), LocalDateTime.now()).getOrThrow()
 }
 
-fun CommonMessage<MessageContent>.textOrNull(): String? = content.asTextContent()?.text
+fun ChatContentMessage<MessageContent>.textOrNull(): String? = content.asTextContent()?.text

--- a/bot/src/main/kotlin/me/centralhardware/znatoki/telegram/statistic/telegram/conversation/LessonConversation.kt
+++ b/bot/src/main/kotlin/me/centralhardware/znatoki/telegram/statistic/telegram/conversation/LessonConversation.kt
@@ -8,7 +8,7 @@ import dev.inmo.tgbotapi.extensions.utils.types.buttons.dataButton
 import dev.inmo.tgbotapi.extensions.utils.types.buttons.inlineKeyboard
 import dev.inmo.tgbotapi.requests.abstracts.InputFile
 import dev.inmo.tgbotapi.types.buttons.ReplyKeyboardRemove
-import dev.inmo.tgbotapi.types.message.abstracts.CommonMessage
+import dev.inmo.tgbotapi.types.message.abstracts.ChatContentMessage
 import dev.inmo.tgbotapi.types.message.content.MessageContent
 import dev.inmo.tgbotapi.utils.row
 import kotlinx.coroutines.runBlocking
@@ -37,7 +37,7 @@ import me.centralhardware.znatoki.telegram.statistic.validateTutor
  * Creates a new lesson using wait-based conversation flow
  */
 suspend fun BehaviourContext.createLesson(
-    message: CommonMessage<MessageContent>,
+    message: ChatContentMessage<MessageContent>,
     canAddForOthers: Boolean = false
 ) {
     val chatId = message.chat.id

--- a/bot/src/main/kotlin/me/centralhardware/znatoki/telegram/statistic/telegram/conversation/PaymentConversation.kt
+++ b/bot/src/main/kotlin/me/centralhardware/znatoki/telegram/statistic/telegram/conversation/PaymentConversation.kt
@@ -8,7 +8,7 @@ import dev.inmo.tgbotapi.extensions.utils.types.buttons.dataButton
 import dev.inmo.tgbotapi.extensions.utils.types.buttons.inlineKeyboard
 import dev.inmo.tgbotapi.requests.abstracts.InputFile
 import dev.inmo.tgbotapi.types.buttons.ReplyKeyboardRemove
-import dev.inmo.tgbotapi.types.message.abstracts.CommonMessage
+import dev.inmo.tgbotapi.types.message.abstracts.ChatContentMessage
 import dev.inmo.tgbotapi.types.message.content.MessageContent
 import dev.inmo.tgbotapi.utils.row
 import kotlinx.coroutines.runBlocking
@@ -41,7 +41,7 @@ import me.centralhardware.znatoki.telegram.statistic.extensions.user
  * Creates a new payment using wait-based conversation flow
  */
 suspend fun BehaviourContext.createPayment(
-    message: CommonMessage<MessageContent>,
+    message: ChatContentMessage<MessageContent>,
     canAddForOthers: Boolean = false
 ) {
     val chatId = message.chat.id

--- a/bot/src/main/kotlin/me/centralhardware/znatoki/telegram/statistic/telegram/conversation/StudentConversation.kt
+++ b/bot/src/main/kotlin/me/centralhardware/znatoki/telegram/statistic/telegram/conversation/StudentConversation.kt
@@ -4,7 +4,7 @@ import dev.inmo.tgbotapi.extensions.api.send.sendTextMessage
 import dev.inmo.tgbotapi.extensions.behaviour_builder.BehaviourContext
 import dev.inmo.tgbotapi.types.buttons.ReplyKeyboardRemove
 import dev.inmo.tgbotapi.types.message.MarkdownParseMode
-import dev.inmo.tgbotapi.types.message.abstracts.CommonMessage
+import dev.inmo.tgbotapi.types.message.abstracts.ChatContentMessage
 import dev.inmo.tgbotapi.types.message.content.MessageContent
 import me.centralhardware.telegram.conversation.CANCEL
 import me.centralhardware.telegram.conversation.ConversationCancelledException
@@ -31,7 +31,7 @@ import me.centralhardware.znatoki.telegram.statistic.telegram.parsePhone
 /**
  * Creates a new student using wait-based conversation flow
  */
-suspend fun BehaviourContext.createStudent(message: CommonMessage<MessageContent>) {
+suspend fun BehaviourContext.createStudent(message: ChatContentMessage<MessageContent>) {
     val chatId = message.chat.id
     val builder = ClientBuilder()
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     api("dev.inmo:krontab:2.9.0")
 
     // Telegram (brings tgbotapi + kslog transitively)
-    api("com.github.centralhardware:ktgbotapi-commons:bf997d37")
+    api("com.github.centralhardware:ktgbotapi-commons:eb3d7671")
 
     // Test dependencies
     testImplementation("org.junit.jupiter:junit-jupiter:6.1.0")


### PR DESCRIPTION
Bumps tgbotapi to 34.0.0 and ktgbotapi-commons to `eb3d7671` (which merged the 34.0.0 upgrade). Renamed `CommonMessage` → `ChatContentMessage` where needed. Builds locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)