### PR TITLE
Bump ktgbotapi-commons to pick up ktgbotapi 35.1.0

### DIFF
--- a/bot/build.gradle.kts
+++ b/bot/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 dependencies {
     implementation(project(":common"))
 
-    implementation("com.github.centralhardware:ktgbotapi-commons:3b24b76e")
+    implementation("com.github.centralhardware:ktgbotapi-commons:4db3d261")
 }
 
 jib {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     api("dev.inmo:krontab:2.9.0")
 
     // Telegram (brings tgbotapi + kslog transitively)
-    api("com.github.centralhardware:ktgbotapi-commons:3b24b76e")
+    api("com.github.centralhardware:ktgbotapi-commons:4db3d261")
 
     // Test dependencies
     testImplementation("org.junit.jupiter:junit-jupiter:6.1.1")


### PR DESCRIPTION
Bumps `ktgbotapi-commons` pin to 4db3d261 to pick up ktgbotapi 35.1.0 transitively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)